### PR TITLE
优化输入密码时的体验

### DIFF
--- a/src/views/pms/user/index.vue
+++ b/src/views/pms/user/index.vue
@@ -77,7 +77,7 @@
             trigger: ['input', 'blur'],
           }"
         >
-          <n-input v-model:value="modalForm.password" />
+          <n-input v-model:value="modalForm.password" type="password" show-password-on="mousedown" />
         </n-form-item>
 
         <n-form-item v-if="['add', 'setRole'].includes(modalAction)" label="角色" path="roleIds">

--- a/src/views/profile/index.vue
+++ b/src/views/profile/index.vue
@@ -73,10 +73,10 @@
         require-mark-placement="left"
       >
         <n-form-item label="原密码" path="oldPassword" :rule="required">
-          <n-input v-model:value="pwdForm.oldPassword" type="password" placeholder="请输入原密码" />
+          <n-input v-model:value="pwdForm.oldPassword" type="password" placeholder="请输入原密码" show-password-on="mousedown" />
         </n-form-item>
         <n-form-item label="新密码" path="newPassword" :rule="required">
-          <n-input v-model:value="pwdForm.newPassword" type="password" placeholder="请输入新密码" />
+          <n-input v-model:value="pwdForm.newPassword" type="password" placeholder="请输入新密码" show-password-on="mousedown" />
         </n-form-item>
       </n-form>
     </MeModal>


### PR DESCRIPTION
这个模板太酷了 😀

此 pr 涉及两处变更：

1. **个人资料-修改密码** 支持在输入密码时通过按住 `icon` 显示密码。

![image](https://github.com/user-attachments/assets/a6451797-db63-43f6-8522-28e1bd5357bb)

2. **用户管理-重置密码** 原 input 改为 `password` 类型，且支持在输入密码时通过按住 `icon` 显示密码。

![image](https://github.com/user-attachments/assets/7fd659a4-38b8-4093-ae29-8db78196f81d)

